### PR TITLE
0.0.2: Framework Update

### DIFF
--- a/src/LevelServices.Test/LevelServices.Test.csproj
+++ b/src/LevelServices.Test/LevelServices.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LevelServices.Test/TileBasedLevelServiceTests.cs
+++ b/src/LevelServices.Test/TileBasedLevelServiceTests.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System.IO;
 using System.Xml.Serialization;
 
-namespace LevelServices.Test
+namespace LPSoft.LevelServices.Test
 {
     public class TileBasedLevelServiceTests
     {

--- a/src/LevelServices/Interfaces/ILevelService.cs
+++ b/src/LevelServices/Interfaces/ILevelService.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Luke Parker. All rights reserved.
 // </copyright>
 
-namespace LevelServices.Interfaces
+namespace LPSoft.LevelServices.Interfaces
 {
     using System.IO;
 

--- a/src/LevelServices/LevelService.cs
+++ b/src/LevelServices/LevelService.cs
@@ -2,12 +2,12 @@
 // Copyright (c) Luke Parker. All rights reserved.
 // </copyright>
 
-namespace LevelServices
+namespace LPSoft.LevelServices
 {
     using System;
     using System.IO;
     using System.Xml.Serialization;
-    using LevelServices.Interfaces;
+    using LPSoft.LevelServices.Interfaces;
 
     /// <summary>
     /// Implements the <see cref="ILevelService{TMapData}"/>.

--- a/src/LevelServices/LevelServices.csproj
+++ b/src/LevelServices/LevelServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/lparkermg/LPSoft.LevelServices/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/lparkermg/LPSoft.LevelServices/</RepositoryUrl>


### PR DESCRIPTION
# Release Notes

Updates framework to target `netstandard2.0` rather than using net5.0 for the moment.